### PR TITLE
(13) Extend records other than scores to include owner info + migrate existing data

### DIFF
--- a/components/models/Models.js
+++ b/components/models/Models.js
@@ -84,6 +84,12 @@ export default class Models extends React.Component {
             <ColumnDefinition
               id="owner"
               title="Owner"
+              customHeadingComponent={(props) => <FilterCellContainer
+                    autoCompleteData={this.props.autoCompleteData}
+                    namespace={Config.modelInstancesNamespace}
+                    onFilterUpdate={this.props.onFilterUpdate}
+                    filterName="owner"
+                    {...props} />}
               order={5}
             />
 

--- a/components/models/ModelsContainer.js
+++ b/components/models/ModelsContainer.js
@@ -24,7 +24,7 @@ const mapStateToProps = state => {
           }
       },
       data: state.models.data,
-      autoCompleteData: { name: [], class: [], tags: [] },
+      autoCompleteData: { name: [], class: [], tags: [], owner: [] },
       griddleComponents: {
           Filter: () => null,
           SettingsToggle: () => null,

--- a/components/tests/Tests.js
+++ b/components/tests/Tests.js
@@ -77,6 +77,12 @@ export default class Tests extends React.Component {
             <ColumnDefinition
               id="owner"
               title="Owner"
+              customHeadingComponent={(props) => <FilterCellContainer
+                    autoCompleteData={this.props.autoCompleteData}
+                    namespace={Config.modelInstancesNamespace}
+                    onFilterUpdate={this.props.onFilterUpdate}
+                    filterName="owner"
+                    {...props} />}
               order={4}
             />
 

--- a/components/tests/TestsContainer.js
+++ b/components/tests/TestsContainer.js
@@ -24,7 +24,7 @@ const mapStateToProps = state => {
           }
       },
       data: state.testInstances.data,
-      autoCompleteData: { name: [], class: [], tags: [] },
+      autoCompleteData: { name: [], class: [], tags: [], owner: [] },
       griddleComponents: {
           Filter: () => null,
           SettingsToggle: () => null,

--- a/shared/adapter/ModelsGriddleAdapter.js
+++ b/shared/adapter/ModelsGriddleAdapter.js
@@ -27,7 +27,7 @@ export default class ModelsGriddleAdapter extends BaseAdapter {
                 class: model.model_class.class_name,
                 tags: model.tags.map((item) => item.name),
                 source: model.url,
-                owner: "?",
+                owner: model.owner.username,
                 timestamp: fullDate
             });
         }

--- a/shared/adapter/TestInstancesGriddleAdapter.js
+++ b/shared/adapter/TestInstancesGriddleAdapter.js
@@ -26,8 +26,8 @@ export default class TestInstancesGriddleAdapter extends BaseAdapter {
                 name: test.test_class.class_name,
                 class: test.test_class.class_name,
                 tags: test.tags.map((item) => item.name),
-                owner: "?",
                 timestamp: fullDate,
+                owner: test.owner.username,
                 _timestamp: test.timestamp,
                 block: false
             });


### PR DESCRIPTION
#(13) Extend records other than scores to include owner info + migrate existing data
https://trello.com/c/TbnEHXwy/314-13-extend-records-other-than-scores-to-include-owner-info-migrate-existing-data

## Changes
Owner name in table, filtering by owner
