### PR TITLE
Feature filter and logged

### DIFF
--- a/components/model-edit/ModelEdit.js
+++ b/components/model-edit/ModelEdit.js
@@ -1,12 +1,13 @@
 import React from "react";
 import ModelForm from "../model-form/ModelForm";
 
-const ModelCreate = ({ model, modelClasses, onSave, onCancel, actionType }) => (<ModelForm
+const ModelCreate = ({ model, modelClasses, onSave, onCancel, actionType, data }) => (<ModelForm
     modelClasses={modelClasses}
     model={model}
     onSave={onSave}
     onCancel={onCancel}
     actionType={actionType}
+    data={data}
 />
 );
 

--- a/components/model-edit/ModelEditContainer.js
+++ b/components/model-edit/ModelEditContainer.js
@@ -8,6 +8,8 @@ import PagesService from "../../services/PagesService";
 const mapStateToProps = state => ({
     model: new ModelInstance(state.router.location.state.model),
     modelClasses: state.modelClasses.data,
+    errors: state.global.errors,
+    data: state.models.data,
     actionType: "edit"
 });
 

--- a/components/model-form/ModelForm.js
+++ b/components/model-form/ModelForm.js
@@ -37,7 +37,8 @@ export default class ModelForm extends React.Component {
       paramsDisabled: true,
       newTag: "",
       modelParamsOpen: false,
-      validationFailed: false
+      validationFailed: false,
+      isBlocked: false
     };
 
 
@@ -50,6 +51,7 @@ export default class ModelForm extends React.Component {
     this.modelFactory = GEPPETTO.ModelFactory;
     this.deleteTag = this.deleteTag.bind(this);
     this.addTag = this.addTag.bind(this);
+    this.isInstanceBlocked = this.isInstanceBlocked.bind(this);
   }
 
   getModelClassError (){
@@ -215,6 +217,28 @@ export default class ModelForm extends React.Component {
     }, () => callback());
   }
 
+  isInstanceBlocked() {
+    let testId = this.props.model.id;
+    var checkInstance = function(value, index, array) { return value.id === testId };
+    var instance = this.props.data.find(checkInstance);
+    if((this.state.isBlocked === false) && (instance.block.isBlocked || (instance.tags.indexOf("deprecated") !== -1))) {
+      this.setState({isBlocked: true});
+    }
+  }
+
+  componentWillMount() {
+    if(this.props.actionType === "edit") {
+      this.checkUrl(this.state.model.url);
+      this.isInstanceBlocked();
+    }
+  }
+
+  componentDidUpdate() {
+    if(this.props.actionType === "edit") {
+      this.isInstanceBlocked();
+    }
+  }
+
   render () {
 
     return (
@@ -230,6 +254,7 @@ export default class ModelForm extends React.Component {
               floatingLabelText="Name of the model"
               underlineStyle={{ borderBottom: "1px solid grey" }}
               onChange={(event, value) => this.updateModel({ name: value })}
+              disabled={this.state.isBlocked}
             />
             <TextField
               value={this.state.model.url}
@@ -254,6 +279,7 @@ export default class ModelForm extends React.Component {
                   });
                 }
               }
+              disabled={this.state.isBlocked}
             />
             <span className="icons">
               {this.state.successClasses ? <SvgIcon style={{ color: "green" }}>{OKicon}</SvgIcon> : null}
@@ -293,6 +319,7 @@ export default class ModelForm extends React.Component {
                   }
                 }
               }}
+              disabled={this.state.isBlocked}
             >
               {this.state.modelClasses.map(klass => <MenuItem value={klass.id} key={klass.id} primaryText={klass.class_name} label={klass.class_name} />)}
             </SelectField>
@@ -378,6 +405,7 @@ export default class ModelForm extends React.Component {
               params={this.state.params}
               onCheck={this.saveChecked}
               onUncheck={this.removeChecked}
+              disabled={this.state.isBlocked}
             />
           </Dialog>
         </div>

--- a/components/model-form/ParamsTable.js
+++ b/components/model-form/ParamsTable.js
@@ -133,7 +133,8 @@ export default class ParamsTable extends React.Component {
             customComponent={enhancedWithRowData(
               this.props.onCheck,
               this.props.onUncheck,
-              this.state.watchedVariables
+              this.state.watchedVariables,
+              this.props.disabled
             )(
               ChooseVarComponent
             )}

--- a/components/model-form/partials.js
+++ b/components/model-form/partials.js
@@ -8,11 +8,12 @@ export const rowDataSelector = (state, { griddleKey }) => state
   .find(rowMap => rowMap.get("griddleKey") === griddleKey)
   .toJSON();
 
-export const enhancedWithRowData = (onCheck, onUncheck, watchedVariables) => connect((state, props) => ({
+export const enhancedWithRowData = (onCheck, onUncheck, watchedVariables, disabled) => connect((state, props) => ({
   rowData: rowDataSelector(state, props),
   onCheck,
   onUncheck,
-  watchedVariables
+  watchedVariables,
+  disabled
 }));
 
 export class ChooseVarComponent extends React.Component{
@@ -55,6 +56,7 @@ export class ChooseVarComponent extends React.Component{
             this.state.toggled
           }
           onToggle={this.onToggle}
+          disabled={this.props.disabled}
         />
       </div>
     );

--- a/components/models/Models.js
+++ b/components/models/Models.js
@@ -13,6 +13,16 @@ export default class Models extends React.Component {
   constructor (props, context){
     super(props, context);
     this.props = props;
+
+    this.username = this.props.user.isLogged ? this.props.user.userObject.username : "";
+  }
+
+  componentWillMount() {
+    if(this.props.user.isLogged) {
+      this.props.onFilterUpdate(this.username, "owner");
+    } else {
+      this.props.notLoggedRedirect()
+    }
   }
 
   render (){
@@ -89,6 +99,7 @@ export default class Models extends React.Component {
                 namespace={Config.modelInstancesNamespace}
                 onFilterUpdate={this.props.onFilterUpdate}
                 filterName="owner"
+                value={this.username}
                 {...props}
               />)}
               order={5}

--- a/components/models/ModelsContainer.js
+++ b/components/models/ModelsContainer.js
@@ -57,6 +57,7 @@ const mapStateToProps = state => ({
     currentPage: 1
   },
   showLoading: state.scores.showLoading,
+  user: state.user,
 });
 
 
@@ -98,7 +99,8 @@ const mapDispatchToProps = dispatch => {
     },
     clone: modelId => dispatch(cloneModel(modelId, dispatch)),
     edit: modelId => dispatch(startEditModel(modelId, dispatch)),
-    toggleCreateModel: () => dispatch(changePage(pagesService.MODELS_CREATE_PAGE, dispatch))
+    toggleCreateModel: () => dispatch(changePage(pagesService.MODELS_CREATE_PAGE, dispatch)),
+    notLoggedRedirect: () => dispatch(changePage(pagesService.SCORES_PAGE, dispatch))
   };
 };
 

--- a/components/models/partial.js
+++ b/components/models/partial.js
@@ -30,6 +30,9 @@ export class CustomMenu extends Component {
   }
 
   isBlocked() {
+    if(this.props.value === undefined) {
+      return false
+    }
     if(this.props.value.get("isBlocked")) {
       return true;
     }

--- a/components/models/partial.js
+++ b/components/models/partial.js
@@ -25,13 +25,28 @@ export class CustomMenu extends Component {
     this.state = {
       anchorEl: null
     };
+
+    this.isBlocked = this.isBlocked.bind(this);
+  }
+
+  isBlocked() {
+    if(this.props.value.get("isBlocked")) {
+      return true;
+    }
+    var instanceId = this.props.value.get("modelId");
+    var checkInstance = function(value, index, array) { return value.id === instanceId };
+    var instance = this.props.data.find(checkInstance);
+    if((instance.tags.indexOf("deprecated") !== -1)) {
+      return true;
+    }
+    return false;
   }
 
   render () {
     const { anchorEl } = this.state;
     return (
       <span className="edit-clone-test">
-        <FontIcon className="fa fa-lock" />
+        { this.isBlocked() && <FontIcon className="fa fa-lock" /> }
         <IconButton
           iconClassName="fa fa-ellipsis-v"
           onClick={e => this.setState({ anchorEl: e.currentTarget })}

--- a/components/page/Drawer/Drawer.js
+++ b/components/page/Drawer/Drawer.js
@@ -45,41 +45,85 @@ export default ({ drawerActive, changePage, toggleDrawer, activePage, editModelA
           leftIcon={<i className="fa fa-star-half-o drawer-icon" />}
           onClick={() => handleMenuClick(pagesService.SCORES_PAGE)}
         />
-        <MenuItem
-          id="hamMenuSuites"
-          primaryText="Suite scores"
-          leftIcon={<i className="fa fa-suitcase drawer-icon" />}
-          onClick={() => handleMenuClick(pagesService.SUITES_PAGE)}
-          disabled={!userLogged}
-        />
-        <MenuItem
-          id="hamMenuTests"
-          primaryText="Tests"
-          onClick={() => handleMenuClick(pagesService.TESTS_PAGE)}
-          leftIcon={<i className="fa fa-laptop drawer-icon" />}
-          disabled={!userLogged}
-        />
-        <MenuItem
-          id="hamMenuModels"
-          primaryText="Models"
-          onClick={() => handleMenuClick(pagesService.MODELS_PAGE)}
-          leftIcon={<i id="gpt-3dshow" className="gpt-3dshow drawer-icon" />}
-          disabled={!userLogged}
-        />
+
+        {userLogged == true 
+        ? (<MenuItem
+            id="hamMenuSuites"
+            primaryText="Suite scores"
+            leftIcon={<i className="fa fa-suitcase drawer-icon" />}
+            onClick={() => handleMenuClick(pagesService.SUITES_PAGE)}
+            disabled={!userLogged}
+          />) 
+        : (<span data-tooltip-right="User must be logged in to view this page">
+          <MenuItem
+            id="hamMenuSuites"
+            primaryText="Suite scores"
+            leftIcon={<i className="fa fa-suitcase drawer-icon" />}
+            onClick={() => handleMenuClick(pagesService.SUITES_PAGE)}
+            disabled={!userLogged}
+          />
+        </span>)}
+
+        {userLogged == true 
+        ? (<MenuItem
+            id="hamMenuTests"
+            primaryText="Tests"
+            onClick={() => handleMenuClick(pagesService.TESTS_PAGE)}
+            leftIcon={<i className="fa fa-laptop drawer-icon" />}
+            disabled={!userLogged}
+          />) 
+        : (<span data-tooltip-right="User must be logged in to view this page">
+          <MenuItem
+            id="hamMenuTests"
+            primaryText="Tests"
+            onClick={() => handleMenuClick(pagesService.TESTS_PAGE)}
+            leftIcon={<i className="fa fa-laptop drawer-icon" />}
+            disabled={!userLogged}
+          />
+        </span>)}
+
+        {userLogged == true 
+        ? (<MenuItem
+            id="hamMenuModels"
+            primaryText="Models"
+            onClick={() => handleMenuClick(pagesService.MODELS_PAGE)}
+            leftIcon={<i id="gpt-3dshow" className="gpt-3dshow drawer-icon" />}
+            disabled={!userLogged}
+          />) 
+        : (<span data-tooltip-right="User must be logged in to view this page">
+          <MenuItem
+            id="hamMenuModels"
+            primaryText="Models"
+            onClick={() => handleMenuClick(pagesService.MODELS_PAGE)}
+            leftIcon={<i id="gpt-3dshow" className="gpt-3dshow drawer-icon" />}
+            disabled={!userLogged}
+          />
+        </span>)}
+
         <MenuItem
           id="hamMenuSettings"
           primaryText="Settings"
           leftIcon={<i className="fa fa-cogs drawer-icon" />}
           onClick={() => handleMenuClick(pagesService.SETTINGS_PAGE)}
+        />
 
-        />
-        <MenuItem
-          id="hamMenuScheduling"
-          primaryText="Scheduling"
-          leftIcon={<i className="fa fa-calendar drawer-icon" />}
-          onClick={() => handleMenuClick(pagesService.SCHEDULING_PAGE)}
-          disabled={!userLogged}
-        />
+        {userLogged == true 
+        ? (<MenuItem
+            id="hamMenuScheduling"
+            primaryText="Scheduling"
+            leftIcon={<i className="fa fa-calendar drawer-icon" />}
+            onClick={() => handleMenuClick(pagesService.SCHEDULING_PAGE)}
+            disabled={!userLogged}
+          />) 
+        : (<span data-tooltip-right="User must be logged in to view this page">
+          <MenuItem
+            id="hamMenuScheduling"
+            primaryText="Scheduling"
+            leftIcon={<i className="fa fa-calendar drawer-icon" />}
+            onClick={() => handleMenuClick(pagesService.SCHEDULING_PAGE)}
+            disabled={!userLogged}
+          />
+        </span>)}
       </Drawer>
     </div>
   );

--- a/components/page/Drawer/Drawer.js
+++ b/components/page/Drawer/Drawer.js
@@ -7,13 +7,21 @@ import NavigationMenu from "material-ui/svg-icons/navigation/menu";
 import ScidashLogo from "../../../assets/scidash_logo.png";
 import PagesService from "../../../services/PagesService";
 
-export default ({ drawerActive, changePage, toggleDrawer, activePage, editModelActive, editTestActive }) => {
+export default ({ drawerActive, changePage, toggleDrawer, activePage, editModelActive, editTestActive, userLogged }) => {
   const pagesService = new PagesService();
 
   const handleMenuClick = page => {
     changePage(page);
     toggleDrawer();
   };
+
+  const handleClickUserLogged = page => {
+    if(userLogged) {
+      handleMenuClick(page);
+    } else {
+      handleMenuClick(pagesService.SCORES_PAGE);
+    }
+  }
 
   return (
     <div>
@@ -42,18 +50,21 @@ export default ({ drawerActive, changePage, toggleDrawer, activePage, editModelA
           primaryText="Suite scores"
           leftIcon={<i className="fa fa-suitcase drawer-icon" />}
           onClick={() => handleMenuClick(pagesService.SUITES_PAGE)}
+          disabled={!userLogged}
         />
         <MenuItem
           id="hamMenuTests"
           primaryText="Tests"
           onClick={() => handleMenuClick(pagesService.TESTS_PAGE)}
           leftIcon={<i className="fa fa-laptop drawer-icon" />}
+          disabled={!userLogged}
         />
         <MenuItem
           id="hamMenuModels"
           primaryText="Models"
           onClick={() => handleMenuClick(pagesService.MODELS_PAGE)}
           leftIcon={<i id="gpt-3dshow" className="gpt-3dshow drawer-icon" />}
+          disabled={!userLogged}
         />
         <MenuItem
           id="hamMenuSettings"
@@ -67,6 +78,7 @@ export default ({ drawerActive, changePage, toggleDrawer, activePage, editModelA
           primaryText="Scheduling"
           leftIcon={<i className="fa fa-calendar drawer-icon" />}
           onClick={() => handleMenuClick(pagesService.SCHEDULING_PAGE)}
+          disabled={!userLogged}
         />
       </Drawer>
     </div>

--- a/components/page/Drawer/DrawerContainer.js
+++ b/components/page/Drawer/DrawerContainer.js
@@ -6,6 +6,7 @@ import { toggleDrawer, changePage } from "../../../actions/creators/header";
 
 const mapStateToProps = state => ({
   drawerActive: state.header.drawerActive,
+  userLogged: state.user.isLogged,
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/components/scheduling/Scheduling.js
+++ b/components/scheduling/Scheduling.js
@@ -79,6 +79,12 @@ class Scheduling extends React.Component {
 
   }
 
+  componentWillMount() {
+    if(!this.props.user.isLogged) {
+      this.props.notLoggedRedirect()
+    }
+  }
+
   render () {
     const { saveSuites, suitesName } = this.state;
 

--- a/components/scheduling/SchedulingContainer.js
+++ b/components/scheduling/SchedulingContainer.js
@@ -1,17 +1,25 @@
 import { connect } from "react-redux";
 import Scheduling from "./Scheduling";
 
+import { changePage } from "../../actions/creators/header";
+import PagesService from "../../services/PagesService";
+
 const mapStateToProps = state => ({
   data: [
-    ...state.models.data,
-    ...state.testInstances.data
+    ...state.models.data.filter(instance => instance.owner === state.user.userObject.username),
+    ...state.testInstances.data.filter(instance => instance.owner === state.user.userObject.username)
   ],
   choosedTests: state.scheduler.choosedTests,
-  choosedModels: state.scheduler.choosedModels
+  choosedModels: state.scheduler.choosedModels,
+  user: state.user,
 });
 
-const mapDispatchToProps = dispatch => ({
-});
+const mapDispatchToProps = dispatch => {
+  let pagesService = new PagesService();
+  return {
+    notLoggedRedirect: () => dispatch(changePage(pagesService.SCORES_PAGE, dispatch))
+  }
+};
 
 export default connect(
   mapStateToProps,

--- a/components/scores/Scores.js
+++ b/components/scores/Scores.js
@@ -21,6 +21,13 @@ export default class Scores extends React.Component {
     super(props, context);
 
     this.props = props;
+    this.username = this.props.user.isLogged ? this.props.user.userObject.username : "";
+  }
+
+  componentWillMount() {
+    if(this.props.user.isLogged) {
+      this.props.onFilterUpdate(this.username, "owner");
+    }
   }
 
   render () {
@@ -108,6 +115,7 @@ export default class Scores extends React.Component {
                 namespace={Config.instancesNamespace}
                 onFilterUpdate={this.props.onFilterUpdate}
                 filterName="owner"
+                value={this.username}
                 {...props}
               />)
               } order={8}

--- a/components/scores/ScoresContainer.js
+++ b/components/scores/ScoresContainer.js
@@ -55,6 +55,7 @@ const mapStateToProps = state => ({
   },
   showLoading: state.scores.showLoading,
   dateFilterChanged: state.scores.dateFilterChanged,
+  user: state.user,
 });
 
 const mapDispatchToProps = dispatch => {

--- a/components/test-edit/TestEdit.js
+++ b/components/test-edit/TestEdit.js
@@ -1,7 +1,7 @@
 import React from "react";
 import TestForm from "../test-form/TestForm";
 
-const TestCreate = ({ model, testClasses, errors, onSave, onCancel, actionType }) => { 
+const TestCreate = ({ model, testClasses, errors, onSave, onCancel, actionType, data }) => { 
   let errorsTemplate = null;
 
   if (errors.length > 0){
@@ -18,6 +18,7 @@ const TestCreate = ({ model, testClasses, errors, onSave, onCancel, actionType }
         onSave={onSave}
         onCancel={onCancel}
         actionType={actionType}
+        data={data}
       />
     </div>
   );

--- a/components/test-edit/TestEditContainer.js
+++ b/components/test-edit/TestEditContainer.js
@@ -9,6 +9,7 @@ const mapStateToProps = state => ({
   model: new TestInstance(state.router.location.state.test),
   testClasses: state.testClasses.data,
   errors: state.global.errors,
+  data: state.testInstances.data,
   actionType: "edit"
 });
 

--- a/components/test-form/ParamsForm.js
+++ b/components/test-form/ParamsForm.js
@@ -75,6 +75,7 @@ export default class ParamsForm extends React.Component {
           style={{ width: "100%" }}
           floatingLabelText={`${key} (${this.state.unitsMap[key]})`}
           underlineStyle={{ borderBottom: "1px solid grey" }}
+          disabled={this.props.disabled}
         />)}.bind(this) 
         )}
       </span>

--- a/components/test-form/ParamsFormset.js
+++ b/components/test-form/ParamsFormset.js
@@ -71,6 +71,7 @@ export default class ParamsFormset extends React.Component {
             floatingLabelText="Select observation schema"
             floatingLabelFixed={false}
             underlineStyle={{ borderBottom: "1px solid grey" }}
+            disabled={this.props.disabled}
           >
             {this.state.schemaList.map((value, index) =>
             // eslint-disable-next-line react/no-array-index-key
@@ -84,6 +85,7 @@ export default class ParamsFormset extends React.Component {
           schema={this.state.schemaList[this.state.choosedForm]}
           onChange={this.props.onChange}
           model={this.props.model}
+          disabled={this.props.disabled}
         />
 
       </span>

--- a/components/test-form/TestForm.js
+++ b/components/test-form/TestForm.js
@@ -18,7 +18,8 @@ export default class TestForm extends React.Component {
       testClasses: props.testClasses,
       model: props.model,
       validationFailed: false,
-      newTag: ""
+      newTag: "",
+      isBlocked: false
     };
 
     this.helper = new Helper();
@@ -28,6 +29,7 @@ export default class TestForm extends React.Component {
     this.onCancel = props.onCancel.bind(this);
     this.deleteTag = this.deleteTag.bind(this);
     this.addTag = this.addTag.bind(this);
+    this.isInstanceBlocked = this.isInstanceBlocked.bind(this);
   }
 
   updateModel (data) {
@@ -62,6 +64,27 @@ export default class TestForm extends React.Component {
     }
   }
 
+  isInstanceBlocked() {
+    let testId = this.props.model.id;
+    var checkInstance = function(value, index, array) { return value.id === testId };
+    var instance = this.props.data.find(checkInstance);
+    if((this.state.isBlocked === false) && (instance.block.isBlocked || (instance.tags.indexOf("deprecated") !== -1))) {
+      this.setState({isBlocked: true});
+    }
+  }
+
+  componentWillMount() {
+    if(this.props.actionType === "edit") {
+      this.isInstanceBlocked();
+    }
+  }
+
+  componentDidUpdate() {
+    if(this.props.actionType === "edit") {
+      this.isInstanceBlocked();
+    }
+  }
+
   render () {
     return (
       <span>
@@ -75,6 +98,7 @@ export default class TestForm extends React.Component {
             style={styles.firstLine.one}
             floatingLabelText="Name of the test"
             underlineStyle={{ borderBottom: "1px solid grey" }}
+            disabled={this.state.isBlocked}
           />
 
           <SelectField
@@ -106,6 +130,7 @@ export default class TestForm extends React.Component {
                 }
               }
             }}
+            disabled={this.state.isBlocked}
           >
 
             {/* eslint-disable-next-line react/no-array-index-key */}
@@ -120,6 +145,7 @@ export default class TestForm extends React.Component {
             style={styles.secondLine.one}
             floatingLabelText="Test description"
             underlineStyle={{ borderBottom: "1px solid grey" }}
+            disabled={this.state.isBlocked}
           />
         </div>
 
@@ -176,6 +202,7 @@ export default class TestForm extends React.Component {
                 });
               }}
               model={this.props.actionType === "edit" ? this.state.model.observation : undefined}
+              disabled={this.state.isBlocked}
             />
           </div>
 
@@ -195,6 +222,7 @@ export default class TestForm extends React.Component {
                 });
               }}
               model={this.props.actionType === "edit" ? this.state.model.params : undefined}
+              disabled={this.state.isBlocked}
             />
           </div>
         </div>

--- a/components/tests/Tests.js
+++ b/components/tests/Tests.js
@@ -13,6 +13,16 @@ export default class Tests extends React.Component {
   constructor (props, context){
     super(props, context);
     this.props = props;
+
+    this.username = this.props.user.isLogged ? this.props.user.userObject.username : "";
+  }
+
+  componentWillMount() {
+    if(this.props.user.isLogged) {
+      this.props.onFilterUpdate(this.username, "owner");
+    } else {
+      this.props.notLoggedRedirect()
+    }
   }
 
   render (){
@@ -82,6 +92,7 @@ export default class Tests extends React.Component {
                 namespace={Config.testInstancesNamespace}
                 onFilterUpdate={this.props.onFilterUpdate}
                 filterName="owner"
+                value={this.username}
                 {...props}
               />)}
               order={4}

--- a/components/tests/TestsContainer.js
+++ b/components/tests/TestsContainer.js
@@ -15,6 +15,7 @@ import {
 
 import Tests from "./Tests";
 import PagesService from "../../services/PagesService";
+import { ActionVerifiedUser } from "material-ui/svg-icons";
 
 const mapStateToProps = state => ({
   styleConfig: {
@@ -59,6 +60,7 @@ const mapStateToProps = state => ({
     currentPage: 1
   },
   showLoading: state.scores.showLoading,
+  user: state.user,
 });
 
 const mapDispatchToProps = dispatch => {
@@ -98,7 +100,8 @@ const mapDispatchToProps = dispatch => {
     },
     clone: testId => dispatch(cloneTest(testId, dispatch)),
     edit: testId => dispatch(startEditTest(testId, dispatch)),
-    toggleCreateTest: () => dispatch(changePage(pagesService.TESTS_CREATE_PAGE, dispatch))
+    toggleCreateTest: () => dispatch(changePage(pagesService.TESTS_CREATE_PAGE, dispatch)),
+    notLoggedRedirect: () => dispatch(changePage(pagesService.SCORES_PAGE, dispatch))
   };
 };
 

--- a/components/tests/partial.js
+++ b/components/tests/partial.js
@@ -30,6 +30,9 @@ export class CustomMenu extends Component {
   }
 
   isBlocked() {
+    if(this.props.value === undefined) {
+      return false
+    }
     if(this.props.value.get("isBlocked")) {
       return true;
     }

--- a/components/tests/partial.js
+++ b/components/tests/partial.js
@@ -25,15 +25,28 @@ export class CustomMenu extends Component {
     this.state = {
       anchorEl: null
     };
+
+    this.isBlocked = this.isBlocked.bind(this);
+  }
+
+  isBlocked() {
+    if(this.props.value.get("isBlocked")) {
+      return true;
+    }
+    var instanceId = this.props.value.get("testId");
+    var checkInstance = function(value, index, array) { return value.id === instanceId };
+    var instance = this.props.data.find(checkInstance);
+    if((instance.tags.indexOf("deprecated") !== -1)) {
+      return true;
+    }
+    return false;
   }
 
   render () {
     const { anchorEl } = this.state;
     return (
       <span className="edit-clone-test">
-        {this.props.value.get("isBlocked") &&
-          <FontIcon className="fa fa-lock" />
-        }
+        { this.isBlocked() && <FontIcon className="fa fa-lock" /> }
         <IconButton
           iconClassName="fa fa-ellipsis-v"
           onClick={e => this.setState({ anchorEl: e.currentTarget })}

--- a/styles/scidash.less
+++ b/styles/scidash.less
@@ -446,6 +446,75 @@ div[role=menu] {
     opacity: 1;
 }
 
+/* Data tooltip on right side */
+
+[data-tooltip-right] {
+    overflow: visible;
+    position: relative;
+    z-index: 2;
+    cursor: pointer;
+}
+
+/* Hide the tooltip content by default */
+
+[data-tooltip-right]:before,
+[data-tooltip-right]:after {
+    visibility: hidden;
+    -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=0)";
+    filter: "progid: DXImageTransform.Microsoft.Alpha(Opacity=0)";
+    opacity: 0;
+    pointer-events: none;
+}
+
+/* Position tooltip above the element */
+
+[data-tooltip-right]:before {
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    margin-bottom: 0px;
+    margin-left: 5px;
+    padding: 3px;
+    width: 160px;
+    -webkit-border-radius: 10px;
+    -moz-border-radius: 10px;
+    border-radius: 10px;
+    background-color: #000;
+    background-color: hsla(0, 0%, 20%, 0.9);
+    color: #fff;
+    content: attr(data-tooltip-right);
+    text-align: center;
+    font-size: 14px;
+    line-height: 1.2;
+}
+
+/* Triangle hack to make tooltip look like a speech bubble */
+
+[data-tooltip-right]:after {
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    margin-left: 5px;
+    width: 0;
+    border-top: 5px solid #000;
+    border-top: 5px solid hsla(0, 0%, 20%, 0.9);
+    border-right: 5px solid transparent;
+    border-left: 5px solid transparent;
+    content: " ";
+    font-size: 0;
+    line-height: 0;
+}
+
+/* Show tooltip content on hover */
+
+[data-tooltip-right]:hover:before,
+[data-tooltip-right]:hover:after {
+    visibility: visible;
+    -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";
+    filter: "progid: DXImageTransform.Microsoft.Alpha(Opacity=100)";
+    opacity: 1;
+}
+
 ::-webkit-scrollbar,
 ::-webkit-scrollbar-thumb {
     width: 0.4em;


### PR DESCRIPTION
This PR takes care of:

- Menu: Test suites, models, tests and scheduling are now disabled and shows a tooltip if the user is logged out.
- Scores are now filtered per user if the user is logged in, differently all the instances will be showed.
- User not allowed to the pages Models, tests, scheduling and test suites even if using the manual url , it will be redirected to the scores page.
- Models and tests are now filtered per username logged in by default.
- Scheduling page now showing only tests and models that belongs to the user logged in.