### PR TITLE
Fix ui fixes

### DIFF
--- a/components/model-form/ParamsTable.js
+++ b/components/model-form/ParamsTable.js
@@ -217,6 +217,7 @@ export default class ParamsTable extends React.Component {
                     margin: "10px 0 10px 0",
                     float: "right"
                   }}
+                  disabled={this.props.disabled}
                   onClick={() => GEPPETTO.trigger(UNTOGGLE_ALL)}
                 />
                 <FlatButton
@@ -224,6 +225,7 @@ export default class ParamsTable extends React.Component {
                     margin: "10px 0 10px 0",
                     float: "right"
                   }}
+                  disabled={this.props.disabled}
                   onClick={() => GEPPETTO.trigger(TOGGLE_ALL)}
                 />
               </span>

--- a/components/models/Models.js
+++ b/components/models/Models.js
@@ -73,7 +73,15 @@ export default class Models extends React.Component {
             <ColumnDefinition
               id="source"
               title="Source"
-              customComponent={props => <a href={props.value} style={{ color: "grey" }}><i className="fa fa-external-link" /></a>}
+              customComponent={props => {
+                  var inputString = props.value.replace(/\s/g, '');
+                  if(inputString !== "") {
+                    return <a href={props.value} style={{ color: "grey" }}><i className="fa fa-external-link" /></a>
+                  } else {
+                    return <span></span>
+                  }
+                }
+              }
               order={3}
             />
 

--- a/components/models/partial.js
+++ b/components/models/partial.js
@@ -28,6 +28,7 @@ export class CustomMenu extends Component {
 
     this.isBlocked = this.isBlocked.bind(this);
     this.checkInstance = this.checkInstance.bind(this);
+    this.checkUserRights = this.checkUserRights.bind(this);
   }
 
   isBlocked() {
@@ -57,6 +58,20 @@ export class CustomMenu extends Component {
     }
   }
 
+  checkUserRights() {
+    if(this.props.value === false || this.props.value === undefined) {
+      return false
+    } else {
+      var instanceId = this.props.value.get("modelId");
+      var checkInstance = function(value, index, array) { return value.id === instanceId };
+      var instance = this.props.data.find(checkInstance);
+      if(instance.owner === this.props.user.userObject.username) {
+        return false;
+      }
+      return true;
+    }
+  }
+
   render () {
     const { anchorEl } = this.state;
     return (
@@ -77,8 +92,17 @@ export class CustomMenu extends Component {
           <Menu>
             <MenuItem
               primaryText="Edit"
-              onClick={() => this.props.edit(this.props.value.get("modelId"))}
+              onClick={() => 
+                {
+                  if(this.checkUserRights()) {
+                    return false;
+                  } else {
+                    this.props.edit(this.props.value.get("modelId"));
+                  }
+                }
+              }
               leftIcon={<FontIcon className="fa fa-pencil-square-o" />}
+              disabled={this.checkUserRights()}
             />
             <MenuItem
               primaryText="Clone"

--- a/components/models/partial.js
+++ b/components/models/partial.js
@@ -27,9 +27,13 @@ export class CustomMenu extends Component {
     };
 
     this.isBlocked = this.isBlocked.bind(this);
+    this.checkInstance = this.checkInstance.bind(this);
   }
 
   isBlocked() {
+    if(this.props.value === false) {
+      return false;
+    }
     if(this.props.value === undefined) {
       return false
     }
@@ -45,15 +49,23 @@ export class CustomMenu extends Component {
     return false;
   }
 
+  checkInstance() {
+    if(this.props.value === false || this.props.value === undefined) {
+      return false
+    } else {
+      return true;
+    }
+  }
+
   render () {
     const { anchorEl } = this.state;
     return (
       <span className="edit-clone-test">
         { this.isBlocked() && <FontIcon className="fa fa-lock" /> }
-        <IconButton
+        { this.checkInstance() && <IconButton
           iconClassName="fa fa-ellipsis-v"
           onClick={e => this.setState({ anchorEl: e.currentTarget })}
-        />
+        /> }
 
         <Popover
           open={!!anchorEl}

--- a/components/page/Drawer/Drawer.js
+++ b/components/page/Drawer/Drawer.js
@@ -46,23 +46,12 @@ export default ({ drawerActive, changePage, toggleDrawer, activePage, editModelA
           onClick={() => handleMenuClick(pagesService.SCORES_PAGE)}
         />
 
-        {userLogged == true 
-        ? (<MenuItem
-            id="hamMenuSuites"
-            primaryText="Suite scores"
-            leftIcon={<i className="fa fa-suitcase drawer-icon" />}
-            onClick={() => handleMenuClick(pagesService.SUITES_PAGE)}
-            disabled={!userLogged}
-          />) 
-        : (<span data-tooltip-right="User must be logged in to view this page">
-          <MenuItem
-            id="hamMenuSuites"
-            primaryText="Suite scores"
-            leftIcon={<i className="fa fa-suitcase drawer-icon" />}
-            onClick={() => handleMenuClick(pagesService.SUITES_PAGE)}
-            disabled={!userLogged}
-          />
-        </span>)}
+        <MenuItem
+          id="hamMenuSuites"
+          primaryText="Suite scores"
+          leftIcon={<i className="fa fa-suitcase drawer-icon" />}
+          onClick={() => handleMenuClick(pagesService.SUITES_PAGE)}
+        />
 
         {userLogged == true 
         ? (<MenuItem

--- a/components/scheduling/DDListContainer.js
+++ b/components/scheduling/DDListContainer.js
@@ -4,8 +4,8 @@ import * as actions from "../../actions/creators/scheduler";
 
 const mapStateToProps = state => ({
   data: [
-    ...state.models.data,
-    ...state.testInstances.data
+    ...state.models.data.filter(instance => instance.owner === state.user.userObject.username),
+    ...state.testInstances.data.filter(instance => instance.owner === state.user.userObject.username)
   ],
   choosedTests: state.scheduler.choosedTests,
   choosedModels: state.scheduler.choosedModels

--- a/components/tests/partial.js
+++ b/components/tests/partial.js
@@ -27,11 +27,15 @@ export class CustomMenu extends Component {
     };
 
     this.isBlocked = this.isBlocked.bind(this);
+    this.checkInstance = this.checkInstance.bind(this);
   }
 
   isBlocked() {
+    if(this.props.value === false) {
+      return false;
+    }
     if(this.props.value === undefined) {
-      return false
+      return false;
     }
     if(this.props.value.get("isBlocked")) {
       return true;
@@ -45,15 +49,23 @@ export class CustomMenu extends Component {
     return false;
   }
 
+  checkInstance() {
+    if(this.props.value === false || this.props.value === undefined) {
+      return false
+    } else {
+      return true;
+    }
+  }
+
   render () {
     const { anchorEl } = this.state;
     return (
       <span className="edit-clone-test">
         { this.isBlocked() && <FontIcon className="fa fa-lock" /> }
-        <IconButton
+        { this.checkInstance() && <IconButton
           iconClassName="fa fa-ellipsis-v"
           onClick={e => this.setState({ anchorEl: e.currentTarget })}
-        />
+        /> }
 
         <Popover
           open={!!anchorEl}

--- a/components/tests/partial.js
+++ b/components/tests/partial.js
@@ -28,6 +28,7 @@ export class CustomMenu extends Component {
 
     this.isBlocked = this.isBlocked.bind(this);
     this.checkInstance = this.checkInstance.bind(this);
+    this.checkUserRights = this.checkUserRights.bind(this);
   }
 
   isBlocked() {
@@ -57,6 +58,20 @@ export class CustomMenu extends Component {
     }
   }
 
+  checkUserRights() {
+    if(this.props.value === false || this.props.value === undefined) {
+      return false
+    } else {
+      var instanceId = this.props.value.get("testId");
+      var checkInstance = function(value, index, array) { return value.id === instanceId };
+      var instance = this.props.data.find(checkInstance);
+      if(instance.owner === this.props.user.userObject.username) {
+        return false;
+      }
+      return true;
+    }
+  }
+
   render () {
     const { anchorEl } = this.state;
     return (
@@ -77,8 +92,17 @@ export class CustomMenu extends Component {
           <Menu>
             <MenuItem
               primaryText="Edit"
-              onClick={() => this.props.edit(this.props.value.get("testId"))}
+              onClick={() => 
+                {
+                  if(this.checkUserRights()) {
+                    return false;
+                  } else {
+                    this.props.edit(this.props.value.get("testId"));
+                  }
+                }
+              }
               leftIcon={<FontIcon className="fa fa-pencil-square-o" />}
+              disabled={this.checkUserRights()}
             />
             <MenuItem
               primaryText="Clone"


### PR DESCRIPTION
-   Models and Tests view fixes if empty view has to be displayed and other small fixes.
-   Toggle and untoggle buttons disabled if the model is locked or deprecated.
-   Models and tests views, fixed edit instance of another user that was allowed, fixed some filters to detect the instance locked by ran or deprecated tag.
-   Suites scores visible again if the user is logged out, as per client feedback.
-   Fixed filter per models and tests instances in the list on the left, now allowing only instances that belongs to the right owner so the user logged in.
