### PR TITLE
fix: test class_name to long error

### DIFF
--- a/actions/creators/tests.js
+++ b/actions/creators/tests.js
@@ -193,6 +193,7 @@ export function editTest (test, dispatch){
   }
 
   test.tags = tagObjects;
+  test.test_class.class_name = test.test_class.class_name.split(" ")[0];
 
   apiService.update(test).then(result => result.json()).then(result => {
     dispatch(editTestFinished(result, dispatch));


### PR DESCRIPTION
# Saving a test class resulted in ERROR: value too long for type
#443 

## Changes
removed the import path from the class_name on save

